### PR TITLE
test: Fix version require

### DIFF
--- a/test/sus/fixtures/async.rb
+++ b/test/sus/fixtures/async.rb
@@ -4,6 +4,7 @@
 # Copyright, 2022, by Samuel Williams.
 
 require 'sus/fixtures/async'
+require 'sus/fixtures/async/version'
 
 describe Sus::Fixtures::Async::VERSION do
 	it 'is a version string' do


### PR DESCRIPTION
When running e.g. 'ruby32 -S sus', I had:
```
🔥 Errored assertions:
file test/sus/fixtures/async.rb:8
        ⚠ NameError: uninitialized constant Sus::Fixtures::Async::VERSION
                test/sus/fixtures/async.rb:8 block in <top (required)>
                /usr/lib64/ruby/gems/3.2.0/gems/sus-0.20.3/lib/sus/file.rb:10 class_eval
                /usr/lib64/ruby/gems/3.2.0/gems/sus-0.20.3/lib/sus/file.rb:10 block in <top (required)>
                /usr/lib64/ruby/gems/3.2.0/gems/sus-0.20.3/lib/sus/file.rb:39 build
                /usr/lib64/ruby/gems/3.2.0/gems/sus-0.20.3/lib/sus/file.rb:105 file
                /usr/lib64/ruby/gems/3.2.0/gems/sus-0.20.3/lib/sus/registry.rb:50 load_file
                /usr/lib64/ruby/gems/3.2.0/gems/sus-0.20.3/lib/sus/registry.rb:45 load
                /usr/lib64/ruby/gems/3.2.0/gems/sus-0.20.3/lib/sus/config.rb:95 block in load_registry
                /usr/lib64/ruby/gems/3.2.0/gems/sus-0.20.3/lib/sus/config.rb:94 each
                /usr/lib64/ruby/gems/3.2.0/gems/sus-0.20.3/lib/sus/config.rb:94 load_registry
                /usr/lib64/ruby/gems/3.2.0/gems/sus-0.20.3/lib/sus/config.rb:82 registry
                /usr/lib64/ruby/gems/3.2.0/gems/sus-0.20.3/bin/sus:10 <top (required)>
                /usr/bin/sus:9 load
                /usr/bin/sus:9 <main>
```

It turns out we're missing a direct require, so chuck it in.

## Types of Changes

- Bug fix.
- Maintenance.

## Contribution

- [X] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
