### PR TITLE
Let's increase the timeout as integration tests can be slow on GA.

### DIFF
--- a/lib/sus/fixtures/async/reactor_context.rb
+++ b/lib/sus/fixtures/async/reactor_context.rb
@@ -54,7 +54,7 @@ module Sus::Fixtures::Async
 		end
 		
 		def timeout
-			10
+			60
 		end
 		
 		def reactor

--- a/test/sus/fixtures/async/reactor_context.rb
+++ b/test/sus/fixtures/async/reactor_context.rb
@@ -14,7 +14,7 @@ describe Sus::Fixtures::Async::ReactorContext do
 		end
 		
 		it "has a default timeout" do
-			expect(timeout).to be == 10
+			expect(timeout).to be == 60
 		end
 		
 		it "can run with timeout" do


### PR DESCRIPTION
While working on https://github.com/socketry/async-webdriver, I found 10s was a little short for some tests. The timeout is designed to catch hung tests, and 60s is probably sufficient for that, while not being a pain for integration tests that might take 20-30s to execute.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
